### PR TITLE
fix: remove log noise

### DIFF
--- a/demo/loadtest.sh
+++ b/demo/loadtest.sh
@@ -16,8 +16,10 @@ fi
 K6_SCRIPT=$(cat <<'EOF'
 import http from 'k6/http';
 import { check } from 'k6';
+import { Counter } from 'k6/metrics';
 
 export const options = {
+  throw: true,
   scenarios: {
     constant_arrival_rate: {
       executor: 'constant-arrival-rate',
@@ -34,13 +36,39 @@ export const options = {
   // noConnectionReuse: true, // Disable HTTP keep-alive, create new connection for each request
 };
 
+const errorCounts = new Counter('request_errors')
+
 export default function () {
-  const res = http.get(__ENV.TARGET, {
-    timeout: "5s"
-  });
-  check(res, {
-    'status is 200': (r) => r.status === 200,
-  });
+  const countMessages = [
+    'connection refused',
+    'request timeout'
+  ]
+
+  try {
+    const res = http.get(__ENV.TARGET, {
+      timeout: "5s"
+    });
+    check(res, {
+      'status is 200': (r) => r.status === 200,
+    });
+  } catch (err) {
+    if (err) {
+      let found = false
+      const errMsg = err.value.toString()
+
+      for (let msg of countMessages) {
+        if (errMsg.includes(msg)) {
+          errorCounts.add(1, { errorType: msg })
+          found = true
+          break
+        }
+      }
+
+      if (!found) {
+        errorCounts.add(1, { errorType: 'Unknown', message: errMsg })
+      }
+    }
+  }
 }
 EOF
 )


### PR DESCRIPTION
The default output of k6 was sending 100s of log lines when there was a request error. These lines:

```sh
time="2025-11-25T00:22:38Z" level=info msg="GoError: Get \"http://10.0.1.248:30000/\": dial tcp 10.0.1.248:30000: connect: connection refused" source=console                                                                           
```
...would blow away the result summary and only the final summary would be visible.

This change catches errors, grouping them by the most common that I witnessed.

Here is what the output looks like now:
```sh
  █ TOTAL RESULTS           
    checks_total.......: 109020  904.85942/s
    checks_succeeded...: 100.00% 109020 out of 109020
    checks_failed......: 0.00%   0 out of 109020
    ✓ status is 200
    CUSTOM                                        
    request_errors.................: 6917   57.410682/s
    HTTP                                 
    http_req_duration..............: avg=347.21ms min=0s       med=188.07ms max=5s    p(90)=851.94ms p(95)=1.05s
      { expected_response:true }...: avg=322.85ms min=3.24ms   med=206.94ms max=5s    p(90)=837.47ms p(95)=1.01s
    http_req_failed................: 5.96%  6917 out of 115937
    http_reqs......................: 115937 962.270102/s                                                            
    EXECUTION                                      
    dropped_iterations.............: 4064   33.730955/s
    iteration_duration.............: avg=547.59ms min=216.06µs med=225.6ms  max=5.03s p(90)=993.34ms p(95)=3.91s
    iterations.....................: 115937 962.270102/s
    vus............................: 765    min=0              max=1000
    vus_max........................: 1000   min=1000           max=1000
    NETWORK                               
    data_received..................: 1.4 GB 12 MB/s
    data_sent......................: 7.9 MB 66 kB/s
```

The `request_errors` under `CUSTOM` is what has been added.

